### PR TITLE
Changes in describe and del commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,17 +111,17 @@ Your can use the follow command to query the status of workflow execution.
 
 or use the follow command to query the detail info for workflow execution.
 
-        genectl describe execution-bf0dc -n default
+        genectl describe execution execution-bf0dc -n default
 
 or use the follow command to delete the workflow execution.
 
-        genectl del execution-bf0dc -n default
+        genectl del execution execution-bf0dc -n default
 ```
 
 Query the detail execution status of workflow:
 
 ```
-$ genectl describe execution-bf0dc -n default
+$ genectl describe execution execution-bf0dc -n default
 Namespace:    default
 Labels:       <none>
 Annotations:  <none>

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ or use the follow command to query the detail info for workflow execution.
 
 or use the follow command to delete the workflow execution.
 
-        genectl del execution execution-bf0dc -n default
+        genectl delete execution execution-bf0dc -n default
 ```
 
 Query the detail execution status of workflow:

--- a/cmd/genectl/commands/delete_execution.go
+++ b/cmd/genectl/commands/delete_execution.go
@@ -24,7 +24,7 @@ import (
 	"kubegene.io/kubegene/cmd/genectl/client"
 )
 
-var delExecExample = `genectl del execution my-exec –n gene-system`
+var delExecExample = `genectl delete execution my-exec –n gene-system`
 
 type delExecutionFlags struct {
 	namespace string
@@ -34,7 +34,7 @@ func NewDeleteCommand() *cobra.Command {
 	var delExecutionFlags delExecutionFlags
 
 	var command = &cobra.Command{
-		Use:     "del execution NAME [flags]",
+		Use:     "delete execution NAME [flags]",
 		Short:   "delete a execution",
 		Args:    cobra.ExactArgs(2),
 		Example: delExecExample,
@@ -49,8 +49,8 @@ func NewDeleteCommand() *cobra.Command {
 }
 
 func DeleteWorkflow(cmd *cobra.Command, args []string, delExecutionFlags *delExecutionFlags) {
-	if args[0] != "execution" {
-		ExitWithError(fmt.Errorf("first args of del execution must be `execution` "))
+	if args[0] != "execution" && args[0] != "executions" {
+		ExitWithError(fmt.Errorf("first args of del execution must be `execution` or `executions` "))
 	}
 	executionName := args[1]
 	if len(executionName) == 0 {

--- a/cmd/genectl/commands/delete_execution.go
+++ b/cmd/genectl/commands/delete_execution.go
@@ -24,7 +24,7 @@ import (
 	"kubegene.io/kubegene/cmd/genectl/client"
 )
 
-var delExecExample = `genectl del my-exec –n gene-system`
+var delExecExample = `genectl del execution my-exec –n gene-system`
 
 type delExecutionFlags struct {
 	namespace string
@@ -34,9 +34,9 @@ func NewDeleteCommand() *cobra.Command {
 	var delExecutionFlags delExecutionFlags
 
 	var command = &cobra.Command{
-		Use:     "del NAME [flags]",
+		Use:     "del execution NAME [flags]",
 		Short:   "delete a execution",
-		Args:    cobra.ExactArgs(1),
+		Args:    cobra.ExactArgs(2),
 		Example: delExecExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			DeleteWorkflow(cmd, args, &delExecutionFlags)
@@ -49,7 +49,10 @@ func NewDeleteCommand() *cobra.Command {
 }
 
 func DeleteWorkflow(cmd *cobra.Command, args []string, delExecutionFlags *delExecutionFlags) {
-	executionName := args[0]
+	if args[0] != "execution" {
+		ExitWithError(fmt.Errorf("first args of del execution must be `execution` "))
+	}
+	executionName := args[1]
 	if len(executionName) == 0 {
 		ExitWithError(fmt.Errorf("executionName can not be empty"))
 	}

--- a/cmd/genectl/commands/describe_execution.go
+++ b/cmd/genectl/commands/describe_execution.go
@@ -56,8 +56,8 @@ func NewDescribeExecutionCommand() *cobra.Command {
 }
 
 func DescribeWorkflow(cmd *cobra.Command, args []string, describeFlags *describeFlags) {
-	if args[0] != "execution" {
-		ExitWithError(fmt.Errorf("first args of describe execution must be `execution` "))
+	if args[0] != "execution" && args[0] != "executions" {
+		ExitWithError(fmt.Errorf("first args of describe execution must be `execution` or `executions` "))
 	}
 	executionName := args[1]
 	if len(executionName) == 0 {

--- a/cmd/genectl/commands/describe_execution.go
+++ b/cmd/genectl/commands/describe_execution.go
@@ -31,6 +31,8 @@ import (
 	execv1alpha1 "kubegene.io/kubegene/pkg/apis/gene/v1alpha1"
 )
 
+var descExecExample = `genectl describe execution my-exec –n gene-system`
+
 type describeFlags struct {
 	namespace string
 }
@@ -39,9 +41,10 @@ func NewDescribeExecutionCommand() *cobra.Command {
 	var describeFlags describeFlags
 
 	var command = &cobra.Command{
-		Use:   "describe",
-		Short: "describe execution info",
-		Args:  cobra.ExactArgs(1),
+		Use:     "describe execution NAME [flags]",
+		Short:   "describe execution info",
+		Args:    cobra.ExactArgs(2),
+		Example: descExecExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			DescribeWorkflow(cmd, args, &describeFlags)
 		},
@@ -53,7 +56,10 @@ func NewDescribeExecutionCommand() *cobra.Command {
 }
 
 func DescribeWorkflow(cmd *cobra.Command, args []string, describeFlags *describeFlags) {
-	executionName := args[0]
+	if args[0] != "execution" {
+		ExitWithError(fmt.Errorf("first args of describe execution must be `execution` "))
+	}
+	executionName := args[1]
 	if len(executionName) == 0 {
 		ExitWithError(fmt.Errorf("executionName can not be empty"))
 	}

--- a/cmd/genectl/commands/sub_workflow.go
+++ b/cmd/genectl/commands/sub_workflow.go
@@ -39,11 +39,11 @@ var submitSuccessMessage = template.Must(template.New("message").Parse(dedent.De
 
 		or use the follow command to query the detail info for workflow execution.
 
-			genectl describe {{ .name }} -n {{ .namespace }}
+			genectl describe execution {{ .name }} -n {{ .namespace }}
 
 		or use the follow command to delete the workflow execution.
 
-			genectl del {{ .name }} -n {{ .namespace }}
+			genectl del execution {{ .name }} -n {{ .namespace }}
 
 		`)))
 

--- a/cmd/genectl/commands/sub_workflow.go
+++ b/cmd/genectl/commands/sub_workflow.go
@@ -43,7 +43,7 @@ var submitSuccessMessage = template.Must(template.New("message").Parse(dedent.De
 
 		or use the follow command to delete the workflow execution.
 
-			genectl del execution {{ .name }} -n {{ .namespace }}
+			genectl delete execution {{ .name }} -n {{ .namespace }}
 
 		`)))
 


### PR DESCRIPTION
Fixes: #32

Fix: 
1)  from `genectl describe  <resource name>`
to  `genectl describe <resource type> <resource name>`

2)  from `genectl del  <resource name>`
to  `genectl delete  <resource type> <resource name>`

