### PR TITLE
Added version feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 .PHONY: all kube-dag genectl clean test e2e
 
-PACKAGE=kubegene.io/kubegene
+PACKAGE=kubegene.io/kubegene/pkg/version
 CURRENT_DIR=$(shell pwd)
 VERSION=$(shell git describe --long --match='v*' --dirty)
 BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,25 @@
 
 .PHONY: all kube-dag genectl clean test e2e
 
+PACKAGE=kubegene.io/kubegene
+CURRENT_DIR=$(shell pwd)
+VERSION=$(shell git describe --long --match='v*' --dirty)
+BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+GIT_COMMIT=$(shell git rev-parse HEAD)
+GIT_TAG=$(shell if [ -z "`git status --porcelain`" ]; then git describe --exact-match --tags HEAD 2>/dev/null; fi)
+GIT_TREE_STATE=$(shell if [ -z "`git status --porcelain`" ]; then echo "clean" ; else echo "dirty"; fi)
+
+
+override LDFLAGS += \
+  -X ${PACKAGE}.version=${VERSION} \
+  -X ${PACKAGE}.buildDate=${BUILD_DATE} \
+  -X ${PACKAGE}.gitCommit=${GIT_COMMIT} \
+  -X ${PACKAGE}.gitTreeState=${GIT_TREE_STATE}
+
+ifneq (${GIT_TAG},)
+override LDFLAGS += -X ${PACKAGE}.gitTag=${GIT_TAG}
+endif
+
 IMAGE_NAME=kube-dag
 TAG=$(shell git rev-parse --short HEAD)
 
@@ -15,11 +34,11 @@ all: kube-dag genectl
 
 kube-dag:
 	mkdir -p bin
-	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o ./bin/kube-dag ./cmd/kube-dag
+	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '${LDFLAGS} -extldflags "-static"' -o ./bin/kube-dag ./cmd/kube-dag
 
 genectl:
 	mkdir -p bin
-	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o ./bin/genectl ./cmd/genectl
+	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '${LDFLAGS} -extldflags "-static"' -o ./bin/genectl ./cmd/genectl
 
 clean:
 	-rm -rf bin

--- a/cmd/genectl/commands/root.go
+++ b/cmd/genectl/commands/root.go
@@ -50,6 +50,7 @@ func NewCommand() *cobra.Command {
 	command.AddCommand(NewDeleteCommand())
 	command.AddCommand(NewDescribeExecutionCommand())
 	command.AddCommand(NewGetExecutionCommand())
+	command.AddCommand(NewVersionCommand())
 
 	return command
 }

--- a/cmd/genectl/commands/version.go
+++ b/cmd/genectl/commands/version.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2018 The Kubegene Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"kubegene.io/kubegene"
+)
+
+var versionExample = `genectl version`
+
+func NewVersionCommand() *cobra.Command {
+
+	var command = &cobra.Command{
+		Use:     "version",
+		Short:   "Print the version information",
+		Long:    "Print the version information",
+		Example: versionExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			VersionInfo(cmd, args)
+		},
+	}
+	return command
+}
+
+func VersionInfo(cmd *cobra.Command, args []string) {
+	version := kubegene.GetVersion()
+	fmt.Printf("  Version: %s\n", version.Version)
+	fmt.Printf("  BuildDate: %s\n", version.BuildDate)
+	fmt.Printf("  GitCommit: %s\n", version.GitCommit)
+	fmt.Printf("  GitTreeState: %s\n", version.GitTreeState)
+	if version.GitTag != "" {
+		fmt.Printf("  GitTag: %s\n", version.GitTag)
+	}
+	fmt.Printf("  GoVersion: %s\n", version.GoVersion)
+	fmt.Printf("  Compiler: %s\n", version.Compiler)
+	fmt.Printf("  Platform: %s\n", version.Platform)
+}

--- a/cmd/genectl/commands/version.go
+++ b/cmd/genectl/commands/version.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubegene Authors.
+Copyright 2019 The Kubegene Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package commands
 import (
 	"fmt"
 	"github.com/spf13/cobra"
-	"kubegene.io/kubegene"
+	"kubegene.io/kubegene/pkg/version"
 )
 
 var versionExample = `genectl version`
@@ -39,15 +39,6 @@ func NewVersionCommand() *cobra.Command {
 }
 
 func VersionInfo(cmd *cobra.Command, args []string) {
-	version := kubegene.GetVersion()
-	fmt.Printf("  Version: %s\n", version.Version)
-	fmt.Printf("  BuildDate: %s\n", version.BuildDate)
-	fmt.Printf("  GitCommit: %s\n", version.GitCommit)
-	fmt.Printf("  GitTreeState: %s\n", version.GitTreeState)
-	if version.GitTag != "" {
-		fmt.Printf("  GitTag: %s\n", version.GitTag)
-	}
-	fmt.Printf("  GoVersion: %s\n", version.GoVersion)
-	fmt.Printf("  Compiler: %s\n", version.Compiler)
-	fmt.Printf("  Platform: %s\n", version.Platform)
+	version := version.GetVersion()
+	fmt.Printf("  genectl Version: %s\n", version)
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
+	"kubegene.io/kubegene"
 	genev1alpha1 "kubegene.io/kubegene/pkg/apis/gene/v1alpha1"
 	geneclientset "kubegene.io/kubegene/pkg/client/clientset/versioned/typed/gene/v1alpha1"
 	geneinformers "kubegene.io/kubegene/pkg/client/informers/externalversions/gene/v1alpha1"
@@ -126,7 +127,7 @@ func (c *ExecutionController) Run(workers int, stopCh <-chan struct{}) {
 	defer c.execQueue.ShutDown()
 	defer c.jobQueue.ShutDown()
 
-	glog.Infof("Starting execution controller")
+	glog.Infof("Starting execution controller with version %s", kubegene.GetVersion())
 	defer glog.Infof("Shutting down execution controller")
 
 	if !cache.WaitForCacheSync(stopCh, c.execSynced, c.jobSynced) {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -33,12 +33,12 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
-	"kubegene.io/kubegene"
 	genev1alpha1 "kubegene.io/kubegene/pkg/apis/gene/v1alpha1"
 	geneclientset "kubegene.io/kubegene/pkg/client/clientset/versioned/typed/gene/v1alpha1"
 	geneinformers "kubegene.io/kubegene/pkg/client/informers/externalversions/gene/v1alpha1"
 	genelisters "kubegene.io/kubegene/pkg/client/listers/gene/v1alpha1"
 	"kubegene.io/kubegene/pkg/util"
+	"kubegene.io/kubegene/pkg/version"
 )
 
 // controllerKind contains the schema.GroupVersionKind for this controller type.
@@ -127,7 +127,7 @@ func (c *ExecutionController) Run(workers int, stopCh <-chan struct{}) {
 	defer c.execQueue.ShutDown()
 	defer c.jobQueue.ShutDown()
 
-	glog.Infof("Starting execution controller with version %s", kubegene.GetVersion())
+	glog.Infof("Starting execution controller with version %s", version.GetVersion())
 	defer glog.Infof("Shutting down execution controller")
 
 	if !cache.WaitForCacheSync(stopCh, c.execSynced, c.jobSynced) {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubegene Authors.
+Copyright 2019 The Kubegene Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubegene
+package version
 
 import (
 	"fmt"
@@ -72,4 +72,19 @@ func GetVersion() Version {
 		Compiler:     runtime.Compiler,
 		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
+}
+
+func (v Version) String() string {
+
+	s := fmt.Sprintf("  Version: %s\n", v.Version)
+	s += fmt.Sprintf("  BuildDate: %s\n", v.BuildDate)
+	s += fmt.Sprintf("  GitCommit: %s\n", v.GitCommit)
+	s += fmt.Sprintf("  GitTreeState: %s\n", v.GitTreeState)
+	if v.GitTag != "" {
+		s += fmt.Sprintf("  GitTag: %s\n", v.GitTag)
+	}
+	s += fmt.Sprintf("  GoVersion: %s\n", v.GoVersion)
+	s += fmt.Sprintf("  Compiler: %s\n", v.Compiler)
+	s += fmt.Sprintf("  Platform: %s\n", v.Platform)
+	return s
 }

--- a/version.go
+++ b/version.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2018 The Kubegene Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubegene
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// Version information set by link flags during build. We fall back to these sane
+// default values when we build outside the Makefile context (e.g. go build or go test).
+var (
+	version      = "0.0.0"                // value from VERSION file
+	buildDate    = "1970-01-01T00:00:00Z" // output from `date -u +'%Y-%m-%dT%H:%M:%SZ'`
+	gitCommit    = ""                     // output from `git rev-parse HEAD`
+	gitTag       = ""                     // output from `git describe --exact-match --tags HEAD` (if clean tree state)
+	gitTreeState = ""                     // determined from `git status --porcelain`. either 'clean' or 'dirty'
+)
+
+// Version contains Argo version information
+type Version struct {
+	Version      string
+	BuildDate    string
+	GitCommit    string
+	GitTag       string
+	GitTreeState string
+	GoVersion    string
+	Compiler     string
+	Platform     string
+}
+
+// GetVersion returns the version information
+func GetVersion() Version {
+	var versionStr string
+	if gitCommit != "" && gitTag != "" && gitTreeState == "clean" {
+		// if we have a clean tree state and the current commit is tagged,
+		versionStr = gitTag
+	} else {
+		// otherwise formulate a version string based on as much metadata
+		// information we have available.
+		versionStr = "v" + version
+		if len(gitCommit) >= 7 {
+			versionStr += "+" + gitCommit[0:7]
+			if gitTreeState != "clean" {
+				versionStr += ".dirty"
+			}
+		} else {
+			versionStr += "+unknown"
+		}
+	}
+	return Version{
+		Version:      versionStr,
+		BuildDate:    buildDate,
+		GitCommit:    gitCommit,
+		GitTag:       gitTag,
+		GitTreeState: gitTreeState,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}


### PR DESCRIPTION
What this PR does / why we need it:
This PR adds version command in genectl & same version info used in kube-dag also.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #33 

